### PR TITLE
Gbfs: Only show recently updated bikes

### DIFF
--- a/gbfs/serializers.py
+++ b/gbfs/serializers.py
@@ -1,3 +1,7 @@
+import pytz
+
+from datetime import datetime, timedelta
+
 from rest_framework import routers, serializers, viewsets
 
 from bikesharing.models import Bike
@@ -28,6 +32,7 @@ class GbfsStationInformationSerializer(serializers.HyperlinkedModelSerializer):
 	class Meta:
 		model = Station
 		fields = ('name', 'capacity', 'station_id', )
+
 	def to_representation(self, instance):
 		representation = super().to_representation(instance)
 		if instance.location is not None and instance.location.x and instance.location.y:
@@ -41,9 +46,10 @@ class GbfsStationStatusSerializer(serializers.HyperlinkedModelSerializer):
 	class Meta:
 		model = Station
 		fields = ('station_id', )
+
 	def to_representation(self, instance):
 		representation = super().to_representation(instance)
-		representation['num_bikes_available'] = instance.bike_set.filter(availability_status='AV').count()
+		representation['num_bikes_available'] = instance.bike_set.filter(availability_status='AV', last_reported__gte=datetime.now(pytz.utc) - timedelta(hours=1)).count()
 		representation['num_docks_available'] = instance.max_bikes - representation['num_bikes_available']
 		status = (instance.status == "AC") or False
 		representation['is_installed'] = status

--- a/gbfs/views.py
+++ b/gbfs/views.py
@@ -65,7 +65,10 @@ class GbfsFreeBikeStatusViewSet(mixins.ListModelMixin, generics.GenericAPIView):
     serializer_class = GbfsFreeBikeStatusSerializer
 
     def get(self, request, *args, **kwargs):
-        bikes = Bike.objects.filter(availability_status='AV')
+        bikes = Bike.objects.filter(
+            availability_status='AV',
+            last_reported__gte=datetime.now(pytz.utc) - timedelta(hours=1)
+        )
         serializer = GbfsFreeBikeStatusSerializer(bikes, many=True)
         bike_data = {
             'bikes': serializer.data

--- a/gbfs/views.py
+++ b/gbfs/views.py
@@ -1,4 +1,7 @@
 import time
+import pytz
+
+from datetime import datetime, timedelta
 
 from django.shortcuts import render
 from rest_framework import routers, serializers, viewsets, mixins, generics
@@ -55,7 +58,10 @@ def gbfsSystemInformation(request):
 
 @permission_classes([AllowAny])        
 class GbfsFreeBikeStatusViewSet(mixins.ListModelMixin, generics.GenericAPIView):
-    queryset = Bike.objects.filter(availability_status='AV')
+    queryset = Bike.objects.filter(
+        availability_status='AV',
+        last_reported__gte=datetime.now(pytz.utc) - timedelta(hours=1)
+        )
     serializer_class = GbfsFreeBikeStatusSerializer
 
     def get(self, request, *args, **kwargs):

--- a/gbfs/views.py
+++ b/gbfs/views.py
@@ -79,7 +79,7 @@ class GbfsFreeBikeStatusViewSet(mixins.ListModelMixin, generics.GenericAPIView):
 
 @permission_classes([AllowAny])
 class GbfsStationInformationViewSet(mixins.ListModelMixin, generics.GenericAPIView):
-    queryset = Station.objects.all()
+    queryset = Station.objects.filter(status='AC')
     serializer_class = GbfsStationInformationSerializer
 
     def get(self, request, *args, **kwargs):
@@ -93,11 +93,11 @@ class GbfsStationInformationViewSet(mixins.ListModelMixin, generics.GenericAPIVi
 
 @permission_classes([AllowAny])
 class GbfsStationStatusViewSet(mixins.ListModelMixin, generics.GenericAPIView):
-    queryset = Station.objects.all()
+    queryset = Station.objects.filter(status='AC')
     serializer_class = GbfsStationStatusSerializer
 
     def get(self, request, *args, **kwargs):
-        stations = Station.objects.all()
+        stations = Station.objects.filter(status='AC')
         serializer = GbfsStationStatusSerializer(stations, many=True)
         station_data = {
             'stations': serializer.data


### PR DESCRIPTION
This changes the gbfs feed of available bikes to include only bikes that
have reported an update within the last hour.

Bikes check whether to report in every 3-8 minutes, and will decide
against reporting up to 5 times in a row if they believe their position
to be unchanged. That means that bikes should check in at least once
within 6 * 8 (= 48) minutes.

TODO: This should be globally configurable instead of hard-coded.

TODO: It would be great if the trackers would monitor their battery
      level and try to fire off a hail mary update before dying.