### PR TITLE
rent: move start/finish in viewset & serializer

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -5,9 +5,6 @@ from rest_framework import serializers
 
 from bikesharing.models import Bike, LocationTracker, Lock, Rent, Station
 
-# class LocationSerializer(serializers.HyperlinkedModelSerializer):
-#    class Meta:
-
 
 class LockSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,9 +1,10 @@
 from allauth.socialaccount.models import SocialApp
 from django.contrib.auth import get_user_model
+from django.contrib.gis.geos import Point
 from django.utils.timezone import now
 from rest_framework import serializers
 
-from bikesharing.models import Bike, LocationTracker, Lock, Rent, Station
+from bikesharing.models import Bike, Location, LocationTracker, Lock, Rent, Station
 
 
 class LockSerializer(serializers.HyperlinkedModelSerializer):
@@ -29,16 +30,85 @@ class StationSerializer(serializers.HyperlinkedModelSerializer):
         fields = ("station_name", "location", "max_bikes", "status")
 
 
-class RentSerializer(serializers.HyperlinkedModelSerializer):
-    bike = BikeSerializer()
+class CreateRentSerializer(serializers.HyperlinkedModelSerializer):
+    bike = serializers.SlugRelatedField(
+        slug_field="bike_number", queryset=Bike.objects.all(), required=True
+    )
+    lat = serializers.CharField(required=False, write_only=True)
+    lng = serializers.CharField(required=False, write_only=True)
+    rent_start = serializers.DateTimeField(default=serializers.CreateOnlyDefault(now))
+    user = serializers.HiddenField(default=serializers.CurrentUserDefault())
 
     class Meta:
         model = Rent
-        fields = (
-            "id",
-            "bike",
-            "rent_start",
-        )
+        fields = ["id", "bike", "lat", "lng", "rent_start", "user"]
+        extra_kwargs = {
+            "lat": {"write_only": True},
+            "lng": {"write_only": True},
+            "user": {"write_only": True},
+        }
+
+    def create(self, validated_data):
+        # drop lat/lng before building rent object
+        data = validated_data
+        data.pop("lat", None)
+        data.pop("lng", None)
+        return Rent.objects.create(**data)
+
+    def save(self, **kwargs):
+        super().save(**kwargs)
+        # FIXME: This method contains too much self.instance. doesn't feel good.
+        # Should this stuff go into the model?
+        self.instance.bike.availability_status = "IU"
+        self.instance.bike.save()
+
+        if (
+            self.validated_data.get("lat") is not None
+            and self.validated_data.get("lng") is not None
+        ):
+            pos = Point(
+                float(self.validated_data.get("lng")),
+                float(self.validated_data.get("lat")),
+                srid=4326,
+            )
+            self.instance.start_position = pos
+
+            loc = Location.objects.create(
+                bike=self.instance.bike, source="US", reported_at=now()
+            )
+            loc.geo = pos
+            loc.save()
+        else:
+            if self.instance.bike.public_geolocation():
+                self.instance.start_position = (
+                    self.instance.bike.public_geolocation().geo
+                )
+            if self.instance.bike.current_station:
+                self.instance.start_station = self.instance.bike.current_station
+
+        self.instance.save()
+
+    def validate_bike(self, value):
+        # seems there is no way to get the already validated and expanded bike obj
+        bike = Bike.objects.get(bike_number=value)
+        if bike.availability_status != "AV":
+            raise serializers.ValidationError("bike is not available")
+        return value
+
+    def validate(self, data):
+        if (data.get("lat") is None and data.get("lng") is not None) or (
+            data.get("lat") is not None and data.get("lng") is None
+        ):
+            raise serializers.ValidationError("lat and lng must be defined together")
+        return data
+
+
+class RentSerializer(serializers.HyperlinkedModelSerializer):
+    bike = BikeSerializer(read_only=True)
+
+    class Meta:
+        model = Rent
+        fields = ["id", "bike", "rent_start"]
 
 
 class SocialAppSerializer(serializers.HyperlinkedModelSerializer):

--- a/api/urls.py
+++ b/api/urls.py
@@ -11,7 +11,6 @@ from .views import (
     updatebikelocation,
 )
 
-# Routers provide an easy way of automatically determining the URL conf.
 router = routers.DefaultRouter()
 
 urlpatterns = [

--- a/api/urls.py
+++ b/api/urls.py
@@ -3,22 +3,18 @@ from django.urls import include, path
 from rest_framework import routers
 
 from .views import (
-    CurrentRentViewSet,
     LoginProviderViewSet,
+    RentViewSet,
     UserDetailsView,
-    finish_rent,
-    start_rent,
     updatebikelocation,
 )
 
-router = routers.DefaultRouter()
+router = routers.DefaultRouter(trailing_slash=False)
+router.register(r"rent", RentViewSet, basename="rent")
 
 urlpatterns = [
     url(r"^", include(router.urls)),
     path("bike/updatelocation", updatebikelocation),
-    path("rent/start", start_rent),
-    path("rent/finish", finish_rent),
-    path("rent/current", CurrentRentViewSet.as_view({"get": "list"})),
     path("user", UserDetailsView.as_view()),
     path("config/loginproviders", LoginProviderViewSet.as_view({"get": "list"})),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -26,16 +26,13 @@ from .serializers import (
     UserDetailsSerializer,
 )
 
-# Create your views here.
-# ViewSets define the view behavior.
 
-
-class BikeViewSet(viewsets.ModelViewSet):
+class BikeViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Bike.objects.all()
     serializer_class = BikeSerializer
 
 
-class StationViewSet(viewsets.ModelViewSet):
+class StationViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Station.objects.all()
     serializer_class = StationSerializer
 
@@ -52,9 +49,6 @@ class CanRentBikePermission(BasePermission):
         return request.user.has_perm("bikesharing.add_rent")
 
 
-"""
-Returns current running Rents of the requesting user
-"""
 
 
 @authentication_classes([authentication.TokenAuthentication])
@@ -238,15 +232,12 @@ class UserDetailsView(generics.RetrieveAPIView):
         return get_user_model().objects.none()
 
 
-"""
-return the configured social login providers
-"""
-
-
 @permission_classes([AllowAny])
 class LoginProviderViewSet(
-    viewsets.ModelViewSet, mixins.ListModelMixin, generics.GenericAPIView
+    mixins.ListModelMixin, viewsets.GenericViewSet,
 ):
+    """return the configured social login providers."""
+
     serializer_class = SocialAppSerializer
 
     def get_queryset(self):

--- a/api/views.py
+++ b/api/views.py
@@ -5,13 +5,8 @@ from django.contrib.gis.measure import D
 from django.contrib.sites.shortcuts import get_current_site
 from django.utils.timezone import now
 from preferences import preferences
-from rest_framework import authentication, generics, mixins, status, viewsets
-from rest_framework.decorators import (
-    action,
-    api_view,
-    authentication_classes,
-    permission_classes,
-)
+from rest_framework import generics, mixins, status, viewsets
+from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.permissions import (
     SAFE_METHODS,
     AllowAny,

--- a/cykel/settings.py
+++ b/cykel/settings.py
@@ -162,6 +162,7 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.TokenAuthentication",
     ],
+    "EXCEPTION_HANDLER": "api.views.custom_exception_handler",
 }
 
 AUTHENTICATION_BACKENDS = (


### PR DESCRIPTION
Our previous way of putting the logic into plain view methods is not quite the [DRF way](https://www.django-rest-framework.org). This PR moves it into the RentViewSet, using two different serializers for writing/creating and reading/listing.
Fixes #20 